### PR TITLE
Expose Earth radius constant for distance calculations

### DIFF
--- a/src/main/java/com/froy/navigator/util/DistanceCalculator.java
+++ b/src/main/java/com/froy/navigator/util/DistanceCalculator.java
@@ -9,7 +9,11 @@ import com.froy.navigator.dto.GeoPoint;
  */
 public class DistanceCalculator {
 
-    private static final int EARTH_RADIUS_KM = 6371; // Earth's radius in kilometers
+    /**
+     * Mean radius of the Earth in kilometers. Exposed for reuse in test cases
+     * and other calculations that need a standard Earth radius value.
+     */
+    public static final double EARTH_RADIUS_KM = 6371.0; // Earth's radius in kilometers
 
     /**
      * Calculates the distance between two geographical points using the Haversine formula.


### PR DESCRIPTION
## Summary
- make Earth radius constant publicly accessible for reuse

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.0 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68995a22151c832e9dafe027bf9d24a7