### PR TITLE
Integrate Swagger and translate documentation to Spanish

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,14 +43,11 @@
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <!-- Solo si eliges Modo B (OpenAPI JSON sin UI) -->
-        <!--
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.6.0</version>
         </dependency>
-        -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/java/com/froy/navigator/NavigatorApplication.java
+++ b/src/main/java/com/froy/navigator/NavigatorApplication.java
@@ -4,6 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+/**
+ * Punto de entrada principal para la aplicación de navegación.
+ */
 public class NavigatorApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/froy/navigator/config/DatasourceConfig.java
+++ b/src/main/java/com/froy/navigator/config/DatasourceConfig.java
@@ -4,12 +4,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 /**
- * Configuration class for JPA repositories.
- * Enables JPA repositories and specifies the base package where repositories are located.
+ * Clase de configuración para los repositorios JPA.
+ * Habilita los repositorios y especifica el paquete base donde se encuentran.
  */
 @Configuration
 @EnableJpaRepositories(basePackages = "com.froy.navigator.repository")
 public class DatasourceConfig {
-    // This class primarily serves to enable JPA repositories.
-    // DataSource configuration is handled via application.yml and application-prod.yml
+    // Esta clase solo habilita los repositorios JPA.
+    // La configuración del DataSource se maneja en application.yml y application-prod.yml
 }

--- a/src/main/java/com/froy/navigator/config/OpenApiConfig.java
+++ b/src/main/java/com/froy/navigator/config/OpenApiConfig.java
@@ -1,0 +1,15 @@
+package com.froy.navigator.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuración de la documentación OpenAPI/Swagger para la aplicación.
+ * Define información básica que será mostrada en la interfaz de Swagger UI.
+ */
+@Configuration
+@OpenAPIDefinition(info = @Info(title = "API de Navegación", version = "v1", description = "API para planificar rutas en diferentes modos de transporte"))
+public class OpenApiConfig {
+    // La configuración se maneja mediante las anotaciones anteriores.
+}

--- a/src/main/java/com/froy/navigator/controller/RouteController.java
+++ b/src/main/java/com/froy/navigator/controller/RouteController.java
@@ -4,6 +4,10 @@ import com.froy.navigator.dto.RouteRequest;
 import com.froy.navigator.dto.RouteResponse;
 import com.froy.navigator.service.RoutePlanner;
 import com.froy.navigator.service.auditing.AuditOperation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,34 +16,41 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * REST Controller for handling route planning requests.
- * Exposes an endpoint to plan routes using different transport modes.
+ * Controlador REST que gestiona las solicitudes de planificación de rutas.
+ * Expone un endpoint para planificar rutas utilizando diferentes modos de transporte.
  */
 @RestController
 @RequestMapping("/api/v1/routes")
+@Tag(name = "Rutas", description = "Operaciones para planificar rutas")
 public class RouteController {
 
     private final RoutePlanner routePlanner;
 
     /**
-     * Constructs a RouteController with the given RoutePlanner.
+     * Crea una instancia de RouteController con el servicio RoutePlanner.
      *
-     * @param routePlanner The service responsible for planning routes.
+     * @param routePlanner Servicio responsable de planificar rutas.
      */
     public RouteController(RoutePlanner routePlanner) {
         this.routePlanner = routePlanner;
     }
 
     /**
-     * Plans a route based on the provided origin, destination, and transport mode.
-     * The request body is validated using Jakarta Bean Validation.
-     * An audit entry is created for each successful route planning operation.
+     * Planifica una ruta basada en el origen, destino y modo de transporte proporcionados.
+     * El cuerpo de la petición se valida con Jakarta Bean Validation.
+     * Se crea una entrada de auditoría por cada planificación exitosa.
      *
-     * @param request The RouteRequest containing the origin, destination, and desired mode.
-     * @return A ResponseEntity containing the RouteResponse with the calculated route details.
+     * @param request Objeto RouteRequest con origen, destino y modo deseado.
+     * @return ResponseEntity con los detalles de la ruta calculada.
      */
     @PostMapping("/plan")
-    @AuditOperation("Route Planned")
+    @AuditOperation("Ruta Planificada")
+    @Operation(summary = "Planificar una ruta", description = "Calcula una ruta entre dos puntos usando un modo de transporte")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Ruta calculada correctamente"),
+            @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
+            @ApiResponse(responseCode = "404", description = "No se encontró la ruta")
+    })
     public ResponseEntity<RouteResponse> planRoute(@Valid @RequestBody RouteRequest request) {
         RouteResponse response = routePlanner.planRoute(request);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/froy/navigator/dto/GeoPoint.java
+++ b/src/main/java/com/froy/navigator/dto/GeoPoint.java
@@ -3,11 +3,11 @@ package com.froy.navigator.dto;
 import com.froy.navigator.validation.GeoCoordinates;
 
 /**
- * Represents a geographical point with latitude and longitude.
- * Used in the RouteRequest DTO.
+ * Representa un punto geográfico con latitud y longitud.
+ * Se utiliza en el DTO RouteRequest.
  */
 public record GeoPoint(
-        @GeoCoordinates(message = "Invalid latitude") double lat,
-        @GeoCoordinates(message = "Invalid longitude") double lon
+        @GeoCoordinates(message = "Latitud inválida") double lat,
+        @GeoCoordinates(message = "Longitud inválida") double lon
 ) {
 }

--- a/src/main/java/com/froy/navigator/dto/RouteRequest.java
+++ b/src/main/java/com/froy/navigator/dto/RouteRequest.java
@@ -5,8 +5,8 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 /**
- * Data Transfer Object for requesting a route plan.
- * Contains the origin, destination, and mode of transport.
+ * Objeto de Transferencia de Datos para solicitar una planificación de ruta.
+ * Contiene el origen, destino y modo de transporte.
  */
 public record RouteRequest(
         @NotNull @Valid GeoPoint origin,

--- a/src/main/java/com/froy/navigator/dto/RouteResponse.java
+++ b/src/main/java/com/froy/navigator/dto/RouteResponse.java
@@ -3,8 +3,8 @@ package com.froy.navigator.dto;
 import java.util.List;
 
 /**
- * Data Transfer Object for the route plan response.
- * Contains the calculated distance, duration, steps, and the mode used.
+ * Objeto de Transferencia de Datos para la respuesta de la planificación de la ruta.
+ * Contiene la distancia calculada, duración, pasos y el modo utilizado.
  */
 public record RouteResponse(
         double distanceKm,

--- a/src/main/java/com/froy/navigator/entity/AuditEntry.java
+++ b/src/main/java/com/froy/navigator/entity/AuditEntry.java
@@ -4,8 +4,8 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 /**
- * Entity representing an audit entry for important operations within the application.
- * Stores details such as action, timestamp, and any relevant messages.
+ * Entidad que representa una entrada de auditoría para operaciones importantes de la aplicación.
+ * Almacena detalles como acción, marca de tiempo y mensajes relevantes.
  */
 @Entity
 @Table(name = "audit_entries")
@@ -21,10 +21,10 @@ public class AuditEntry {
     @Column(nullable = false)
     private LocalDateTime timestamp;
 
-    @Lob // For potentially large text fields
+    @Lob // Para campos de texto potencialmente grandes
     private String message;
 
-    // Default constructor for JPA
+    // Constructor por defecto para JPA
     public AuditEntry() {
     }
 
@@ -34,7 +34,7 @@ public class AuditEntry {
         this.timestamp = LocalDateTime.now();
     }
 
-    // Getters and Setters
+    // Getters y Setters
     public Long getId() {
         return id;
     }

--- a/src/main/java/com/froy/navigator/entity/RouteStats.java
+++ b/src/main/java/com/froy/navigator/entity/RouteStats.java
@@ -4,8 +4,8 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 /**
- * Entity representing statistics for a route calculation.
- * Stores details such as origin, destination, mode, distance, duration, and the time of calculation.
+ * Entidad que representa las estadísticas de un cálculo de ruta.
+ * Almacena detalles como origen, destino, modo, distancia, duración y momento de cálculo.
  */
 @Entity
 @Table(name = "route_stats")
@@ -39,7 +39,7 @@ public class RouteStats {
     @Column(nullable = false)
     private LocalDateTime calculationTime;
 
-    // Default constructor for JPA
+    // Constructor por defecto para JPA
     public RouteStats() {
     }
 
@@ -55,7 +55,7 @@ public class RouteStats {
         this.calculationTime = LocalDateTime.now();
     }
 
-    // Getters and Setters
+    // Getters y Setters
     public Long getId() {
         return id;
     }

--- a/src/main/java/com/froy/navigator/exception/ApiError.java
+++ b/src/main/java/com/froy/navigator/exception/ApiError.java
@@ -5,8 +5,8 @@ import org.springframework.http.HttpStatus;
 import java.time.LocalDateTime;
 
 /**
- * Represents a standardized error response for the API.
- * Includes a timestamp, HTTP status, error message, and optional details.
+ * Representa una respuesta de error estandarizada para la API.
+ * Incluye marca de tiempo, estado HTTP, mensaje de error y detalles opcionales.
  */
 public record ApiError(
         LocalDateTime timestamp,

--- a/src/main/java/com/froy/navigator/exception/BusinessException.java
+++ b/src/main/java/com/froy/navigator/exception/BusinessException.java
@@ -4,8 +4,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 /**
- * Custom exception for business logic errors.
- * Maps to HTTP 400 Bad Request by default.
+ * Excepción personalizada para errores de lógica de negocio.
+ * Se asigna al código HTTP 400 Bad Request por defecto.
  */
 @ResponseStatus(HttpStatus.BAD_REQUEST)
 public class BusinessException extends RuntimeException {

--- a/src/main/java/com/froy/navigator/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/froy/navigator/exception/GlobalExceptionHandler.java
@@ -8,18 +8,18 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 
 /**
- * Global exception handler for the REST API.
- * Catches specific exceptions and returns standardized ApiError responses.
+ * Manejador global de excepciones para la API REST.
+ * Captura excepciones específicas y retorna respuestas ApiError estandarizadas.
  */
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     /**
-     * Handles custom BusinessException and returns a BAD_REQUEST status.
+     * Maneja la BusinessException personalizada y retorna un estado BAD_REQUEST.
      *
-     * @param ex The BusinessException that was thrown.
-     * @param request The web request during which the exception occurred.
-     * @return A ResponseEntity containing an ApiError with BAD_REQUEST status.
+     * @param ex Excepción BusinessException lanzada.
+     * @param request Petición web durante la cual ocurrió la excepción.
+     * @return ResponseEntity con ApiError y estado BAD_REQUEST.
      */
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ApiError> handleBusinessException(BusinessException ex, WebRequest request) {
@@ -32,11 +32,11 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * Handles custom NotFoundException and returns a NOT_FOUND status.
+     * Maneja la NotFoundException personalizada y retorna un estado NOT_FOUND.
      *
-     * @param ex The NotFoundException that was thrown.
-     * @param request The web request during which the exception occurred.
-     * @return A ResponseEntity containing an ApiError with NOT_FOUND status.
+     * @param ex Excepción NotFoundException lanzada.
+     * @param request Petición web durante la cual ocurrió la excepción.
+     * @return ResponseEntity con ApiError y estado NOT_FOUND.
      */
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<ApiError> handleNotFoundException(NotFoundException ex, WebRequest request) {
@@ -49,12 +49,12 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * Handles validation errors caused by @Valid and @Validated annotations.
-     * Extracts error messages from MethodArgumentNotValidException and returns a BAD_REQUEST status.
+     * Maneja los errores de validación provocados por las anotaciones @Valid y @Validated.
+     * Extrae los mensajes de error de MethodArgumentNotValidException y retorna BAD_REQUEST.
      *
-     * @param ex The MethodArgumentNotValidException that was thrown.
-     * @param request The web request during which the exception occurred.
-     * @return A ResponseEntity containing an ApiError with BAD_REQUEST status and validation details.
+     * @param ex Excepción MethodArgumentNotValidException lanzada.
+     * @param request Petición web durante la cual ocurrió la excepción.
+     * @return ResponseEntity con ApiError y detalles de validación.
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiError> handleValidationExceptions(MethodArgumentNotValidException ex, WebRequest request) {
@@ -64,24 +64,24 @@ public class GlobalExceptionHandler {
 
         ApiError apiError = new ApiError(
                 HttpStatus.BAD_REQUEST,
-                "Validation Error",
+                "Error de validación",
                 errors + " - " + request.getDescription(false)
         );
         return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
     }
 
     /**
-     * Catches any other unexpected exceptions and returns an INTERNAL_SERVER_ERROR status.
+     * Captura cualquier otra excepción inesperada y retorna INTERNAL_SERVER_ERROR.
      *
-     * @param ex The unexpected Exception that was thrown.
-     * @param request The web request during which the exception occurred.
-     * @return A ResponseEntity containing an ApiError with INTERNAL_SERVER_ERROR status.
+     * @param ex Excepción inesperada lanzada.
+     * @param request Petición web durante la cual ocurrió la excepción.
+     * @return ResponseEntity con ApiError y estado INTERNAL_SERVER_ERROR.
      */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiError> handleAllUncaughtException(Exception ex, WebRequest request) {
         ApiError apiError = new ApiError(
                 HttpStatus.INTERNAL_SERVER_ERROR,
-                "An unexpected error occurred",
+                "Ocurrió un error inesperado",
                 ex.getLocalizedMessage() + " - " + request.getDescription(false)
         );
         return new ResponseEntity<>(apiError, HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/froy/navigator/exception/NotFoundException.java
+++ b/src/main/java/com/froy/navigator/exception/NotFoundException.java
@@ -4,8 +4,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 /**
- * Custom exception to indicate that a requested resource was not found.
- * Maps to HTTP 404 Not Found.
+ * Excepción personalizada para indicar que un recurso solicitado no fue encontrado.
+ * Se asigna al código HTTP 404 Not Found.
  */
 @ResponseStatus(HttpStatus.NOT_FOUND)
 public class NotFoundException extends RuntimeException {

--- a/src/main/java/com/froy/navigator/repository/AuditEntryRepository.java
+++ b/src/main/java/com/froy/navigator/repository/AuditEntryRepository.java
@@ -5,8 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 /**
- * Repository interface for managing {@link AuditEntry} entities.
- * Provides standard CRUD operations and allows for custom queries if needed.
+ * Interfaz de repositorio para gestionar entidades {@link AuditEntry}.
+ * Proporciona operaciones CRUD estándar y permite consultas personalizadas si es necesario.
  */
 @Repository
 public interface AuditEntryRepository extends JpaRepository<AuditEntry, Long> {

--- a/src/main/java/com/froy/navigator/repository/RouteStatsRepository.java
+++ b/src/main/java/com/froy/navigator/repository/RouteStatsRepository.java
@@ -10,18 +10,18 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 
 /**
- * Repository interface for managing {@link RouteStats} entities.
- * Provides standard CRUD operations and custom native queries for specific statistical needs.
+ * Interfaz de repositorio para gestionar entidades {@link RouteStats}.
+ * Proporciona operaciones CRUD estándar y consultas nativas para necesidades estadísticas específicas.
  */
 @Repository
 public interface RouteStatsRepository extends JpaRepository<RouteStats, Long> {
 
     /**
-     * Deletes all route statistics entries older than a specified date.
-     * This is an example of a native query with a modifying operation.
+     * Elimina todas las entradas de estadísticas de rutas anteriores a una fecha específica.
+     * Ejemplo de una consulta nativa con una operación de modificación.
      *
-     * @param dateTime The threshold date and time. Entries older than this will be deleted.
-     * @return The number of deleted entities.
+     * @param dateTime Fecha y hora límite. Las entradas anteriores serán eliminadas.
+     * @return Número de entidades eliminadas.
      */
     @Modifying
     @Transactional

--- a/src/main/java/com/froy/navigator/service/RoutePlanner.java
+++ b/src/main/java/com/froy/navigator/service/RoutePlanner.java
@@ -14,9 +14,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * Service responsible for planning routes using different strategies.
- * Implements the Context part of the Strategy pattern, dynamically selecting
- * the appropriate RouteStrategy based on the requested mode.
+ * Servicio responsable de planificar rutas utilizando diferentes estrategias.
+ * Implementa la parte de Contexto del patrón Strategy, seleccionando dinámicamente
+ * la RouteStrategy adecuada según el modo solicitado.
  */
 @Service
 public class RoutePlanner {
@@ -25,9 +25,9 @@ public class RoutePlanner {
     private Map<String, RouteStrategy> strategies;
 
     /**
-     * Constructs a RoutePlanner with the Spring ApplicationContext.
+     * Construye un RoutePlanner con el ApplicationContext de Spring.
      *
-     * @param applicationContext The Spring ApplicationContext, used to retrieve all RouteStrategy beans.
+     * @param applicationContext Contexto de Spring utilizado para obtener todos los beans de RouteStrategy.
      */
     @Autowired
     public RoutePlanner(ApplicationContext applicationContext) {
@@ -35,9 +35,9 @@ public class RoutePlanner {
     }
 
     /**
-     * Initializes the map of strategies after the bean has been constructed.
-     * It collects all beans that implement RouteStrategy and maps them by their mode.
-     * This avoids explicit if/else or switch statements for strategy selection.
+     * Inicializa el mapa de estrategias después de la creación del bean.
+     * Recolecta todos los beans que implementan RouteStrategy y los mapea por su modo.
+     * Esto evita utilizar sentencias if/else o switch para seleccionar la estrategia.
      */
     @PostConstruct
     public void init() {
@@ -48,16 +48,16 @@ public class RoutePlanner {
     }
 
     /**
-     * Plans a route based on the provided request and selected transport mode.
+     * Planifica una ruta basada en la solicitud proporcionada y el modo de transporte seleccionado.
      *
-     * @param request The RouteRequest containing origin, destination, and desired mode.
-     * @return A RouteResponse with the calculated route details.
-     * @throws BusinessException if the requested transport mode is not supported.
+     * @param request Objeto RouteRequest que contiene origen, destino y modo deseado.
+     * @return RouteResponse con los detalles de la ruta calculada.
+     * @throws BusinessException si el modo de transporte solicitado no está soportado.
      */
     public RouteResponse planRoute(RouteRequest request) {
         RouteStrategy strategy = strategies.get(request.mode().toUpperCase());
         if (strategy == null) {
-            throw new BusinessException("Unsupported transport mode: " + request.mode());
+            throw new BusinessException("Modo de transporte no soportado: " + request.mode());
         }
         return strategy.compute(request);
     }

--- a/src/main/java/com/froy/navigator/service/auditing/AuditAspect.java
+++ b/src/main/java/com/froy/navigator/service/auditing/AuditAspect.java
@@ -8,9 +8,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
- * Aspect for auditing operations annotated with {@link AuditOperation}.
- * Intercepts method calls, executes the method, and then records an audit entry
- * using the AuditService.
+ * Aspecto para auditar operaciones anotadas con {@link AuditOperation}.
+ * Intercepta las llamadas a métodos, ejecuta el método y luego registra una entrada
+ * de auditoría utilizando AuditService.
  */
 @Aspect
 @Component
@@ -19,9 +19,9 @@ public class AuditAspect {
     private final AuditService auditService;
 
     /**
-     * Constructs an AuditAspect with the given AuditService.
+     * Construye un AuditAspect con el AuditService proporcionado.
      *
-     * @param auditService The service used to persist audit entries.
+     * @param auditService Servicio utilizado para persistir las entradas de auditoría.
      */
     @Autowired
     public AuditAspect(AuditService auditService) {
@@ -29,13 +29,13 @@ public class AuditAspect {
     }
 
     /**
-     * Around advice for methods annotated with @AuditOperation.
-     * It intercepts the method call, executes the original method, and then
-     * logs an audit entry with the action defined in the annotation and the method arguments.
+     * Consejo alrededor para métodos anotados con @AuditOperation.
+     * Intercepta la llamada, ejecuta el método original y registra una entrada de auditoría
+     * con la acción definida en la anotación y los argumentos del método.
      *
-     * @param joinPoint The join point representing the intercepted method.
-     * @return The result of the original method execution.
-     * @throws Throwable if the original method throws an exception.
+     * @param joinPoint Punto de unión que representa el método interceptado.
+     * @return Resultado de la ejecución del método original.
+     * @throws Throwable si el método original lanza una excepción.
      */
     @Around("@annotation(com.froy.navigator.service.auditing.AuditOperation)")
     public Object auditOperation(ProceedingJoinPoint joinPoint) throws Throwable {
@@ -44,15 +44,15 @@ public class AuditAspect {
         String action = auditOperation.value();
 
         Object[] args = joinPoint.getArgs();
-        String message = String.format("Method: %s, Arguments: %s", signature.getName(), java.util.Arrays.toString(args));
+        String message = String.format("Método: %s, Argumentos: %s", signature.getName(), java.util.Arrays.toString(args));
 
         try {
-            Object result = joinPoint.proceed(); // Execute the original method
-            auditService.audit(action, message + ", Result: " + result);
+            Object result = joinPoint.proceed(); // Ejecuta el método original
+            auditService.audit(action, message + ", Resultado: " + result);
             return result;
         } catch (Throwable e) {
             auditService.audit(action, message + ", Error: " + e.getMessage());
-            throw e; // Re-throw the exception after auditing
+            throw e; // Re-lanza la excepción después de auditar
         }
     }
 }

--- a/src/main/java/com/froy/navigator/service/auditing/AuditOperation.java
+++ b/src/main/java/com/froy/navigator/service/auditing/AuditOperation.java
@@ -6,16 +6,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Custom annotation to mark methods for auditing.
- * When a method annotated with @AuditOperation is executed, AuditAspect will intercept it
- * and create an AuditEntry in the database.
+ * Anotación personalizada para marcar métodos que deben ser auditados.
+ * Cuando se ejecuta un método anotado con @AuditOperation, AuditAspect lo intercepta
+ * y crea una entrada de auditoría en la base de datos.
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AuditOperation {
     /**
-     * The description of the audited operation.
-     * @return a String representing the action performed.
+     * Descripción de la operación auditada.
+     * @return Cadena que representa la acción realizada.
      */
     String value();
 }

--- a/src/main/java/com/froy/navigator/service/auditing/AuditService.java
+++ b/src/main/java/com/froy/navigator/service/auditing/AuditService.java
@@ -8,8 +8,8 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Service for managing audit operations.
- * Responsible for saving audit entries to the database.
+ * Servicio para gestionar las operaciones de auditoría.
+ * Responsable de guardar las entradas de auditoría en la base de datos.
  */
 @Service
 public class AuditService {
@@ -17,9 +17,9 @@ public class AuditService {
     private final AuditEntryRepository auditEntryRepository;
 
     /**
-     * Constructs an AuditService with the given AuditEntryRepository.
+     * Construye un AuditService con el AuditEntryRepository proporcionado.
      *
-     * @param auditEntryRepository The repository for audit entries.
+     * @param auditEntryRepository Repositorio para las entradas de auditoría.
      */
     @Autowired
     public AuditService(AuditEntryRepository auditEntryRepository) {
@@ -27,12 +27,12 @@ public class AuditService {
     }
 
     /**
-     * Saves a new audit entry to the database.
-     * Uses Propagation.REQUIRES_NEW to ensure the audit entry is saved
-     * even if the calling transaction fails.
+     * Guarda una nueva entrada de auditoría en la base de datos.
+     * Usa Propagation.REQUIRES_NEW para asegurar que la entrada se persista
+     * incluso si la transacción llamante falla.
      *
-     * @param action The action performed (e.g., "Route Planned").
-     * @param message A detailed message about the audit event.
+     * @param action Acción realizada (p. ej., "Ruta Planificada").
+     * @param message Mensaje detallado sobre el evento de auditoría.
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void audit(String action, String message) {

--- a/src/main/java/com/froy/navigator/strategy/BikeRouteStrategy.java
+++ b/src/main/java/com/froy/navigator/strategy/BikeRouteStrategy.java
@@ -8,8 +8,8 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 /**
- * Concrete strategy for planning routes by bike.
- * Avoids highways and prefers shorter, more scenic routes.
+ * Estrategia concreta para planificar rutas en bicicleta.
+ * Evita las autopistas y prefiere rutas más cortas y escénicas.
  */
 @Component("BIKE")
 public class BikeRouteStrategy implements RouteStrategy {
@@ -17,13 +17,13 @@ public class BikeRouteStrategy implements RouteStrategy {
     @Override
     public RouteResponse compute(RouteRequest request) {
         double distance = DistanceCalculator.calculateDistance(request.origin(), request.destination());
-        // Simulate slower travel for bikes, avoiding highways
-        int duration = (int) (distance / 15 * 60); // 15 km/h average speed
+        // Simula un viaje más lento para bicicletas, evitando autopistas
+        int duration = (int) (distance / 15 * 60); // velocidad promedio 15 km/h
         List<String> steps = List.of(
-                "Start at " + request.origin(),
-                "Follow bike paths and secondary roads",
-                "Avoid highways",
-                "Arrive at " + request.destination()
+                "Inicio en " + request.origin(),
+                "Sigue ciclovías y carreteras secundarias",
+                "Evita autopistas",
+                "Llegada a " + request.destination()
         );
         return new RouteResponse(round(distance), duration, steps, mode());
     }

--- a/src/main/java/com/froy/navigator/strategy/CarRouteStrategy.java
+++ b/src/main/java/com/froy/navigator/strategy/CarRouteStrategy.java
@@ -8,8 +8,8 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 /**
- * Concrete strategy for planning routes by car.
- * Prioritizes speed and uses highways where appropriate.
+ * Estrategia concreta para planificar rutas en automóvil.
+ * Prioriza la velocidad y utiliza autopistas cuando es apropiado.
  */
 @Component("CAR")
 public class CarRouteStrategy implements RouteStrategy {
@@ -17,12 +17,12 @@ public class CarRouteStrategy implements RouteStrategy {
     @Override
     public RouteResponse compute(RouteRequest request) {
         double distance = DistanceCalculator.calculateDistance(request.origin(), request.destination());
-        // Simulate faster travel for cars on highways
-        int duration = (int) (distance / 80 * 60); // 80 km/h average speed
+        // Simula un viaje más rápido para autos en autopistas
+        int duration = (int) (distance / 80 * 60); // velocidad promedio 80 km/h
         List<String> steps = List.of(
-                "Start at " + request.origin(),
-                "Drive on major highways",
-                "Arrive at " + request.destination()
+                "Inicio en " + request.origin(),
+                "Conduce por autopistas principales",
+                "Llegada a " + request.destination()
         );
         return new RouteResponse(round(distance), duration, steps, mode());
     }

--- a/src/main/java/com/froy/navigator/strategy/MotorcycleRouteStrategy.java
+++ b/src/main/java/com/froy/navigator/strategy/MotorcycleRouteStrategy.java
@@ -8,8 +8,9 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 /**
- * Concrete strategy for planning routes by motorcycle.
- * Combines aspects of car and bike strategies, offering a balance of speed and flexibility.
+ * Estrategia concreta para planificar rutas en motocicleta.
+ * Combina aspectos de las estrategias de auto y bicicleta, ofreciendo un balance
+ * entre velocidad y flexibilidad.
  */
 @Component("MOTORCYCLE")
 public class MotorcycleRouteStrategy implements RouteStrategy {
@@ -17,12 +18,12 @@ public class MotorcycleRouteStrategy implements RouteStrategy {
     @Override
     public RouteResponse compute(RouteRequest request) {
         double distance = DistanceCalculator.calculateDistance(request.origin(), request.destination());
-        // Simulate moderate speed for motorcycles, with some flexibility
-        int duration = (int) (distance / 60 * 60); // 60 km/h average speed
+        // Simula una velocidad moderada para motocicletas, con cierta flexibilidad
+        int duration = (int) (distance / 60 * 60); // velocidad promedio 60 km/h
         List<String> steps = List.of(
-                "Start at " + request.origin(),
-                "Take a flexible route, using main roads and some shortcuts",
-                "Arrive at " + request.destination()
+                "Inicio en " + request.origin(),
+                "Toma una ruta flexible, usando carreteras principales y algunos atajos",
+                "Llegada a " + request.destination()
         );
         return new RouteResponse(round(distance), duration, steps, mode());
     }

--- a/src/main/java/com/froy/navigator/strategy/RouteStrategy.java
+++ b/src/main/java/com/froy/navigator/strategy/RouteStrategy.java
@@ -4,24 +4,24 @@ import com.froy.navigator.dto.RouteRequest;
 import com.froy.navigator.dto.RouteResponse;
 
 /**
- * Interface for route planning strategies.
- * Implements the Strategy pattern, allowing different algorithms for route calculation
- * based on the mode of transport.
+ * Interfaz para las estrategias de planificación de rutas.
+ * Implementa el patrón Strategy, permitiendo diferentes algoritmos de cálculo
+ * según el modo de transporte.
  */
 public interface RouteStrategy {
 
     /**
-     * Computes a route based on the given request.
+     * Calcula una ruta basada en la solicitud dada.
      *
-     * @param request The route request containing origin, destination, and mode.
-     * @return A RouteResponse containing the calculated distance, duration, steps, and mode.
+     * @param request Petición de ruta que contiene origen, destino y modo.
+     * @return RouteResponse con distancia, duración, pasos y modo calculados.
      */
     RouteResponse compute(RouteRequest request);
 
     /**
-     * Returns the mode of transport handled by this strategy.
+     * Devuelve el modo de transporte manejado por esta estrategia.
      *
-     * @return A string representing the transport mode (e.g., "CAR", "BIKE", "MOTORCYCLE").
+     * @return Cadena que representa el modo de transporte (ej. "CAR", "BIKE", "MOTORCYCLE").
      */
     String mode();
 }

--- a/src/main/java/com/froy/navigator/util/DistanceCalculator.java
+++ b/src/main/java/com/froy/navigator/util/DistanceCalculator.java
@@ -3,24 +3,24 @@ package com.froy.navigator.util;
 import com.froy.navigator.dto.GeoPoint;
 
 /**
- * Utility class for calculating distances between geographical points.
- * Uses the Haversine formula to calculate the great-circle distance between two points
- * on a sphere given their longitudes and latitudes.
+ * Clase de utilidades para calcular distancias entre puntos geográficos.
+ * Utiliza la fórmula de Haversine para obtener la distancia de gran círculo
+ * entre dos puntos en una esfera dadas sus longitudes y latitudes.
  */
 public class DistanceCalculator {
 
     /**
-     * Mean radius of the Earth in kilometers. Exposed for reuse in test cases
-     * and other calculations that need a standard Earth radius value.
+     * Radio medio de la Tierra en kilómetros. Se expone para reutilizar en pruebas
+     * y otros cálculos que necesiten un valor estándar del radio terrestre.
      */
-    public static final double EARTH_RADIUS_KM = 6371.0; // Earth's radius in kilometers
+    public static final double EARTH_RADIUS_KM = 6371.0; // Radio de la Tierra en kilómetros
 
     /**
-     * Calculates the distance between two geographical points using the Haversine formula.
+     * Calcula la distancia entre dos puntos geográficos usando la fórmula de Haversine.
      *
-     * @param point1 The first geographical point (origin).
-     * @param point2 The second geographical point (destination).
-     * @return The distance between the two points in kilometers.
+     * @param point1 Primer punto geográfico (origen).
+     * @param point2 Segundo punto geográfico (destino).
+     * @return Distancia entre los dos puntos en kilómetros.
      */
     public static double calculateDistance(GeoPoint point1, GeoPoint point2) {
         double lat1Rad = Math.toRadians(point1.lat());

--- a/src/main/java/com/froy/navigator/validation/GeoCoordinates.java
+++ b/src/main/java/com/froy/navigator/validation/GeoCoordinates.java
@@ -8,14 +8,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Custom validation annotation to ensure a value is a valid geographical coordinate.
- * Works for both latitude and longitude.
+ * Anotación de validación personalizada para asegurar que un valor sea una coordenada geográfica válida.
+ * Funciona tanto para latitud como para longitud.
  */
 @Target({ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = GeoCoordinatesValidator.class)
 public @interface GeoCoordinates {
-    String message() default "Invalid geographical coordinates";
+    String message() default "Coordenadas geográficas inválidas";
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/com/froy/navigator/validation/GeoCoordinatesValidator.java
+++ b/src/main/java/com/froy/navigator/validation/GeoCoordinatesValidator.java
@@ -4,8 +4,8 @@ import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
 /**
- * Validator for the @GeoCoordinates annotation.
- * Checks if a double value is within the valid range for latitude or longitude.
+ * Validador para la anotación @GeoCoordinates.
+ * Verifica si un valor double está dentro del rango válido para latitud o longitud.
  */
 public class GeoCoordinatesValidator implements ConstraintValidator<GeoCoordinates, Double> {
 
@@ -14,7 +14,7 @@ public class GeoCoordinatesValidator implements ConstraintValidator<GeoCoordinat
         if (value == null) {
             return false;
         }
-        // Basic validation for latitude (-90 to 90) and longitude (-180 to 180)
+        // Validación básica para latitud (-90 a 90) y longitud (-180 a 180)
         return value >= -180 && value <= 180;
     }
 }

--- a/src/main/java/com/froy/navigator/validation/SupportedMode.java
+++ b/src/main/java/com/froy/navigator/validation/SupportedMode.java
@@ -8,13 +8,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Custom validation annotation to ensure a string value represents a supported transport mode.
+ * Anotación de validación personalizada para asegurar que un valor represente un modo de transporte soportado.
  */
 @Target({ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = SupportedModeValidator.class)
 public @interface SupportedMode {
-    String message() default "Unsupported transport mode. Allowed modes are CAR, BIKE, MOTORCYCLE.";
+    String message() default "Modo de transporte no soportado. Los modos permitidos son CAR, BIKE, MOTORCYCLE.";
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/com/froy/navigator/validation/SupportedModeValidator.java
+++ b/src/main/java/com/froy/navigator/validation/SupportedModeValidator.java
@@ -7,8 +7,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Validator for the @SupportedMode annotation.
- * Checks if the given string mode is one of the predefined supported modes (CAR, BIKE, MOTORCYCLE).
+ * Validador para la anotación @SupportedMode.
+ * Verifica si el modo proporcionado es uno de los modos soportados (CAR, BIKE, MOTORCYCLE).
  */
 public class SupportedModeValidator implements ConstraintValidator<SupportedMode, String> {
 
@@ -18,7 +18,7 @@ public class SupportedModeValidator implements ConstraintValidator<SupportedMode
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
         if (value == null) {
-            return false; // Or true, depending on whether null is considered valid for your use case
+            return false; // O true, dependiendo de si se permite null en tu caso de uso
         }
         return SUPPORTED_MODES.contains(value.toUpperCase());
     }


### PR DESCRIPTION
## Summary
- Add Springdoc OpenAPI dependency and configuration for Swagger UI
- Document and expose route planning endpoint with Swagger annotations
- Translate all class comments and validation messages to Spanish

## Testing
- `mvn -q test` *(fails: Network is unreachable for Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_689962e9a158832ebd90b4237a531d6d