### PR TITLE
feat: log Swagger UI URL and controllers on startup

### DIFF
--- a/src/main/java/com/froy/navigator/config/StartupLogger.java
+++ b/src/main/java/com/froy/navigator/config/StartupLogger.java
@@ -1,0 +1,31 @@
+package com.froy.navigator.config;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+/**
+ * Componente que registra en consola la URL de Swagger UI y los controladores disponibles al iniciar la aplicación.
+ */
+@Component
+public class StartupLogger implements CommandLineRunner {
+
+    private final ApplicationContext context;
+
+    public StartupLogger(ApplicationContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public void run(String... args) {
+        // URL predeterminada de Swagger UI
+        System.out.println("Swagger UI disponible en: http://localhost:8080/swagger-ui.html");
+        // Enumerar controladores y sus rutas
+        RequestMappingHandlerMapping mapping = context.getBean(RequestMappingHandlerMapping.class);
+        mapping.getHandlerMethods().forEach((info, method) -> {
+            Class<?> controller = method.getBeanType();
+            System.out.println("Controlador: " + controller.getSimpleName() + " – ruta: " + info.getPatternsCondition());
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add StartupLogger component to print Swagger UI URL and available controllers when the application boots

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.0 due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689967c139b8832e905fde8fbbdf2fd2