### PR TITLE
Documentar respuestas y modelos OpenAPI

### DIFF
--- a/src/main/java/com/froy/navigator/controller/RouteController.java
+++ b/src/main/java/com/froy/navigator/controller/RouteController.java
@@ -2,9 +2,13 @@ package com.froy.navigator.controller;
 
 import com.froy.navigator.dto.RouteRequest;
 import com.froy.navigator.dto.RouteResponse;
+import com.froy.navigator.exception.ApiError;
 import com.froy.navigator.service.RoutePlanner;
 import com.froy.navigator.service.auditing.AuditOperation;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -47,9 +51,72 @@ public class RouteController {
     @AuditOperation("Ruta Planificada")
     @Operation(summary = "Planificar una ruta", description = "Calcula una ruta entre dos puntos usando un modo de transporte")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Ruta calculada correctamente"),
-            @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
-            @ApiResponse(responseCode = "404", description = "No se encontró la ruta")
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Ruta calculada correctamente",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = RouteResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "rutaEjemplo",
+                                            value = """
+                                                    {
+                                                      "distanceKm": 10.5,
+                                                      "durationMinutes": 25,
+                                                      "steps": [
+                                                        "Salga de Av. Vallarta y continúe 300 m",
+                                                        "Gire a la izquierda en Calle López Cotilla"
+                                                      ],
+                                                      "mode": "driving"
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Solicitud inválida (parámetros incorrectos o incompletos)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiError.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "errorValidacion",
+                                            value = """
+                                                    {
+                                                      "timestamp": "2025-08-10T14:00:00Z",
+                                                      "status": "BAD_REQUEST",
+                                                      "message": "Error de validación",
+                                                      "details": "origin.lat: Latitud inválida; mode: Debe ser 'driving', 'walking' o 'bicycling'"
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "No se encontró una ruta entre los puntos dados",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiError.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "rutaNoEncontrada",
+                                            value = """
+                                                    {
+                                                      "timestamp": "2025-08-10T14:01:00Z",
+                                                      "status": "NOT_FOUND",
+                                                      "message": "No se encontró la ruta",
+                                                      "details": "No hay ruta entre el origen y el destino proporcionados"
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            )
     })
     public ResponseEntity<RouteResponse> planRoute(@Valid @RequestBody RouteRequest request) {
         RouteResponse response = routePlanner.planRoute(request);

--- a/src/main/java/com/froy/navigator/dto/GeoPoint.java
+++ b/src/main/java/com/froy/navigator/dto/GeoPoint.java
@@ -1,13 +1,19 @@
 package com.froy.navigator.dto;
 
 import com.froy.navigator.validation.GeoCoordinates;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * Representa un punto geográfico con latitud y longitud.
  * Se utiliza en el DTO RouteRequest.
  */
 public record GeoPoint(
-        @GeoCoordinates(message = "Latitud inválida") double lat,
-        @GeoCoordinates(message = "Longitud inválida") double lon
+        @GeoCoordinates(message = "Latitud inválida")
+        @Schema(description = "Latitud del punto", example = "20.6736")
+        double lat,
+
+        @GeoCoordinates(message = "Longitud inválida")
+        @Schema(description = "Longitud del punto", example = "-103.344")
+        double lon
 ) {
 }

--- a/src/main/java/com/froy/navigator/dto/RouteRequest.java
+++ b/src/main/java/com/froy/navigator/dto/RouteRequest.java
@@ -3,14 +3,23 @@ package com.froy.navigator.dto;
 import com.froy.navigator.validation.SupportedMode;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * Objeto de Transferencia de Datos para solicitar una planificación de ruta.
  * Contiene el origen, destino y modo de transporte.
  */
 public record RouteRequest(
-        @NotNull @Valid GeoPoint origin,
-        @NotNull @Valid GeoPoint destination,
-        @SupportedMode String mode
+        @NotNull @Valid
+        @Schema(description = "Punto geográfico de origen")
+        GeoPoint origin,
+
+        @NotNull @Valid
+        @Schema(description = "Punto geográfico de destino")
+        GeoPoint destination,
+
+        @SupportedMode
+        @Schema(description = "Modo de transporte", example = "driving")
+        String mode
 ) {
 }

--- a/src/main/java/com/froy/navigator/dto/RouteResponse.java
+++ b/src/main/java/com/froy/navigator/dto/RouteResponse.java
@@ -1,15 +1,26 @@
 package com.froy.navigator.dto;
 
 import java.util.List;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * Objeto de Transferencia de Datos para la respuesta de la planificación de la ruta.
  * Contiene la distancia calculada, duración, pasos y el modo utilizado.
  */
 public record RouteResponse(
+        @Schema(description = "Distancia total en kilómetros", example = "10.5")
         double distanceKm,
+
+        @Schema(description = "Duración estimada en minutos", example = "25")
         int durationMinutes,
+
+        @Schema(
+                description = "Instrucciones paso a paso",
+                example = "[\"Salga de Av. Vallarta y continúe 300 m\", \"Gire a la izquierda en Calle López Cotilla\"]"
+        )
         List<String> steps,
+
+        @Schema(description = "Modo de transporte usado", example = "driving")
         String mode
 ) {
 }

--- a/src/main/java/com/froy/navigator/exception/ApiError.java
+++ b/src/main/java/com/froy/navigator/exception/ApiError.java
@@ -1,17 +1,27 @@
 package com.froy.navigator.exception;
 
 import org.springframework.http.HttpStatus;
-
 import java.time.LocalDateTime;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * Representa una respuesta de error estandarizada para la API.
  * Incluye marca de tiempo, estado HTTP, mensaje de error y detalles opcionales.
  */
 public record ApiError(
+        @Schema(description = "Fecha y hora del error", example = "2025-08-10T14:00:00Z")
         LocalDateTime timestamp,
+
+        @Schema(description = "Código de estado HTTP", example = "BAD_REQUEST")
         HttpStatus status,
+
+        @Schema(description = "Mensaje descriptivo del error", example = "Error de validación")
         String message,
+
+        @Schema(
+                description = "Detalle adicional sobre el error",
+                example = "origin.lat: Latitud inválida; mode: Debe ser 'driving', 'walking' o 'bicycling'"
+        )
         String details
 ) {
     public ApiError(HttpStatus status, String message, String details) {


### PR DESCRIPTION
## Summary
- Enrich RouteController responses with detailed schemas and realistic examples for success and error cases.
- Annotate RouteRequest, RouteResponse, GeoPoint and ApiError DTOs with `@Schema` metadata and example values.

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68996b2f7374832eacfe7cf8a866eb18